### PR TITLE
feat: add multi-arch build (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,9 @@ jobs:
           type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
           type=sha
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v3
@@ -41,6 +44,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         build-args: |
           versionflags=-X 'main.appVersion=${{ github.ref_name }}'
         push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # https://hub.docker.com/_/golang
-FROM docker.io/library/golang:1.25.3-alpine AS build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.3-alpine AS build
 
+ARG TARGETARCH
 ARG versionflags=""
 
 WORKDIR /src
@@ -9,7 +10,7 @@ COPY . .
 
 RUN go mod download
 
-RUN CGO_ENABLED=0 go build -o webhook -ldflags "-w -s -extldflags '-static' ${versionflags}" .
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -o webhook -ldflags "-w -s -extldflags '-static' ${versionflags}" .
 
 FROM gcr.io/distroless/static-debian12:nonroot AS webhook
 


### PR DESCRIPTION
## Что сделано
- Добавлена мульти-арх сборка Docker-образа (linux/amd64 + linux/arm64)
- Добавлен QEMU step для кросс-платформенной сборки
- Dockerfile оптимизирован: `--platform=$BUILDPLATFORM` + `GOARCH=$TARGETARCH` — нативная кросс-компиляция Go без эмуляции (4 мин вместо 10+)

## Зачем
Текущий образ собирается только под amd64. Это не позволяет запускать webhook на ARM64 (например Raspberry Pi 5 с k3s).

## Изменения
- `.github/workflows/release.yaml`: добавлен `docker/setup-qemu-action@v3` и параметр `platforms`
- `Dockerfile`: добавлен `--platform=$BUILDPLATFORM`, `ARG TARGETARCH`, `GOARCH=${TARGETARCH}`